### PR TITLE
Replace before_render event with onPageRendering

### DIFF
--- a/pico_edit.php
+++ b/pico_edit.php
@@ -18,7 +18,7 @@ final class Pico_Edit extends AbstractPicoPlugin {
   private $plugin_path = '';
   private $password = '';
 
-  public function before_render( &$twig_vars, &$twig )
+  public function onPageRendering(Twig_Environment &$twig, array &$twig_vars, &$templateName)
   {
     $twig_vars['pico_edit_url'] = $this->getPageUrl( 'pico_edit' );
     if( $this->is_logout ) {


### PR DESCRIPTION
Pico_Edit is a Pico 1.0 plugin (it extends `AbstractPicoPlugin`), `before_render` is a deprecated event and therefore requires the `PicoDeprecated` plugin. Use `onPageRendering` instead.

@blocknotes, **we'll promote this plugin on http://picocms.org/customization/** until development of the official admin plugin is finished with Pico 1.1. Please merge this as soon as possible. This issue prevents the plugin to work on newer Pico installations without old plugins (i.e. when `PicoDeprecated` doesn't get enabled automatically).
