### PR TITLE
test_git was statically called from pico_edit.php

### DIFF
--- a/Git-php-lib
+++ b/Git-php-lib
@@ -235,7 +235,7 @@ class GitRepo {
 	 * @access  public
 	 * @return  bool
 	 */
-	public function test_git() {
+	public static function test_git() {
 		$descriptorspec = array(
 			1 => array('pipe', 'w'),
 			2 => array('pipe', 'w'),

--- a/editor.html
+++ b/editor.html
@@ -20,6 +20,7 @@
       <a href="#" class="new btn icon-plus marg-r5" title="New"></a>
       <a href="#" class="pushpullbutton btn icon-download2 marg-r5" title="Git Push/Pull"></a>
       <a href="#" class="commitbutton btn icon-upload2 marg-r5" title="Git Commit"></a>
+      <a href="#" class="clearcachebutton btn icon-loop2 marg-r5" title="Clear Cache"></a>
       <a href="{{ pico_edit_url }}/logout" class="logout btn icon-switch" title="Logout"></a>
     </div>
     <ul class="nav0">
@@ -168,6 +169,15 @@
           }, 1000);
         });
       });
+      $('.controls').on('click', '.clearcachebutton', function(e) {
+         $('#saving').text('Clearing...').addClass('active');
+         $.post('{{ pico_edit_url }}/clearcache', {}, function(data){
+           $('#saving').text('Cache cleared');
+           setTimeout(function(){
+                   $('#saving').removeClass('active');
+           }, 1000);
+         });
+       });
       $('.controls').on('click', '.commitbutton', function(e) {
         open_popup();
         $('.popupcontent').load('{{ pico_edit_url }}/commit');

--- a/pico_edit.php
+++ b/pico_edit.php
@@ -137,6 +137,7 @@ final class Pico_Edit extends AbstractPicoPlugin {
     if( $url == 'pico_edit/commit' ) $this->do_commit();
     if( $url == 'pico_edit/git' ) $this->do_git();
     if( $url == 'pico_edit/pushpull' ) $this->do_pushpull();
+    if( $url == 'pico_edit/clearcache' ) $this->do_clearcache();
   }
 
   /**
@@ -521,6 +522,15 @@ final class Pico_Edit extends AbstractPicoPlugin {
 
     die(json_encode($output));
   }
+
+   private function do_clearcache()
+   {
+     if(!isset($_SESSION['backend_logged_in']) || !$_SESSION['backend_logged_in']) die(json_encode(array('error' => 'Error: Unathorized')));
+     $path = $this->getConfig( 'content_dir' ).'/../cache/*';
+     $ret = `rm -rf $path`;
+     // done
+     die($ret);
+   }
 
   private function slugify( $text ) {
     // replace non letter or digits by -

--- a/styles.css
+++ b/styles.css
@@ -201,7 +201,7 @@ a:hover, a:active {
   float: left; 
   margin-top: 5px;
 }
-#sidebar .controls .new, .commitbutton, .savebutton, .pushpullbutton { 
+#sidebar .controls .new, .commitbutton, .savebutton, .pushpullbutton, .clearcachebutton { 
   float: right; 
   margin-top: 5px;
 }


### PR DESCRIPTION
This caused a php warning in the error log whenever pico_edit is used. Simple fix by making test_git a static function instead.

Example warning:
PHP Strict Standards:  Non-static method GitRepo::test_git() should not be called statically, assuming $this from incompatible context in [...]/pico/plugins/pico_edit/pico_edit.php on line 508