### PR TITLE
Fix scrollable area on sidebar file list

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -23,23 +23,21 @@
       <a href="#" class="clearcachebutton btn icon-loop2 marg-r5" title="Clear Cache"></a>
       <a href="{{ pico_edit_url }}/logout" class="logout btn icon-switch" title="Logout"></a>
     </div>
-    <div class="scrollable">
-      <ul class="nav0">
-        {% if config.pico_edit_options %}
-        <li><a href="#" data-url="conf" class="post page-options"><span class="icon-equalizer2 marg-r5" aria-hidden="true"></span><i>config options</i></a></li>
-        {% endif %}
-        {% if config.pico_edit_404 %}
-        <li><a href="#" data-url="/404" class="post page-404"><span class="icon-file-empty marg-r5" aria-hidden="true"></span><i>404</i></a></li>
-        {% endif %}
-      </ul>
-      <ul class="nav">
-      {% for page in pages %}
-        <li><a href="#" data-url="{{ page.id }}" class="post"><span class="icon-file-text2 marg-r5" aria-hidden="true"></span>/{{ page.id }}</a>
-        <a href="{{ page.url }}" target="_blank" class="view" title="View"><span class="icon icon-eye" aria-hidden="true"></span></a>
-        <a href="#" data-url="{{ page.id }}" class="delete" title="Delete"><span class="icon icon-bin" aria-hidden="true"></span></a></li>
-      {% endfor %}
-      </ul>
-    </div>
+    <ul class="nav0">
+      {% if config.pico_edit_options %}
+      <li><a href="#" data-url="conf" class="post page-options"><span class="icon-equalizer2 marg-r5" aria-hidden="true"></span><i>config options</i></a></li>
+      {% endif %}
+      {% if config.pico_edit_404 %}
+      <li><a href="#" data-url="/404" class="post page-404"><span class="icon-file-empty marg-r5" aria-hidden="true"></span><i>404</i></a></li>
+      {% endif %}
+    </ul>
+    <ul class="nav">
+    {% for page in pages %}
+      <li><a href="#" data-url="{{ page.id }}" class="post"><span class="icon-file-text2 marg-r5" aria-hidden="true"></span>/{{ page.id }}</a>
+      <a href="{{ page.url }}" target="_blank" class="view" title="View"><span class="icon icon-eye" aria-hidden="true"></span></a>
+      <a href="#" data-url="{{ page.id }}" class="delete" title="Delete"><span class="icon icon-bin" aria-hidden="true"></span></a></li>
+    {% endfor %}
+    </ul>
   </div>
 
   <div id="main">

--- a/editor.html
+++ b/editor.html
@@ -23,21 +23,23 @@
       <a href="#" class="clearcachebutton btn icon-loop2 marg-r5" title="Clear Cache"></a>
       <a href="{{ pico_edit_url }}/logout" class="logout btn icon-switch" title="Logout"></a>
     </div>
-    <ul class="nav0">
-      {% if config.pico_edit_options %}
-      <li><a href="#" data-url="conf" class="post page-options"><span class="icon-equalizer2 marg-r5" aria-hidden="true"></span><i>config options</i></a></li>
-      {% endif %}
-      {% if config.pico_edit_404 %}
-      <li><a href="#" data-url="/404" class="post page-404"><span class="icon-file-empty marg-r5" aria-hidden="true"></span><i>404</i></a></li>
-      {% endif %}
-    </ul>
-    <ul class="nav">
-    {% for page in pages %}
-      <li><a href="#" data-url="{{ page.id }}" class="post"><span class="icon-file-text2 marg-r5" aria-hidden="true"></span>/{{ page.id }}</a>
-      <a href="{{ page.url }}" target="_blank" class="view" title="View"><span class="icon icon-eye" aria-hidden="true"></span></a>
-      <a href="#" data-url="{{ page.id }}" class="delete" title="Delete"><span class="icon icon-bin" aria-hidden="true"></span></a></li>
-    {% endfor %}
-    </ul>
+    <div class="scrollable">
+      <ul class="nav0">
+        {% if config.pico_edit_options %}
+        <li><a href="#" data-url="conf" class="post page-options"><span class="icon-equalizer2 marg-r5" aria-hidden="true"></span><i>config options</i></a></li>
+        {% endif %}
+        {% if config.pico_edit_404 %}
+        <li><a href="#" data-url="/404" class="post page-404"><span class="icon-file-empty marg-r5" aria-hidden="true"></span><i>404</i></a></li>
+        {% endif %}
+      </ul>
+      <ul class="nav">
+      {% for page in pages %}
+        <li><a href="#" data-url="{{ page.id }}" class="post"><span class="icon-file-text2 marg-r5" aria-hidden="true"></span>/{{ page.id }}</a>
+        <a href="{{ page.url }}" target="_blank" class="view" title="View"><span class="icon icon-eye" aria-hidden="true"></span></a>
+        <a href="#" data-url="{{ page.id }}" class="delete" title="Delete"><span class="icon icon-bin" aria-hidden="true"></span></a></li>
+      {% endfor %}
+      </ul>
+    </div>
   </div>
 
   <div id="main">

--- a/editor.html
+++ b/editor.html
@@ -14,15 +14,16 @@
   </div>
   <div id="saving">Saving...</div>
 
+  <div class="controls">
+    <a href="#" class="savebutton btn icon-floppy-disk" title="Save"></a>
+    <a href="#" class="new btn icon-plus marg-r5" title="New"></a>
+    <a href="#" class="pushpullbutton btn icon-download2 marg-r5" title="Git Push/Pull"></a>
+    <a href="#" class="commitbutton btn icon-upload2 marg-r5" title="Git Commit"></a>
+    <a href="#" class="clearcachebutton btn icon-loop2 marg-r5" title="Clear Cache"></a>
+    <a href="#" class="releasebutton btn icon-upload2 marg-r5" title="Release"></a>
+    <a href="{{ pico_edit_url }}/logout" class="logout btn icon-switch" title="Logout"></a>
+  </div>
   <div id="sidebar">
-    <div class="controls">
-      <a href="#" class="savebutton btn icon-floppy-disk" title="Save"></a>
-      <a href="#" class="new btn icon-plus marg-r5" title="New"></a>
-      <a href="#" class="pushpullbutton btn icon-download2 marg-r5" title="Git Push/Pull"></a>
-      <a href="#" class="commitbutton btn icon-upload2 marg-r5" title="Git Commit"></a>
-      <a href="#" class="clearcachebutton btn icon-loop2 marg-r5" title="Clear Cache"></a>
-      <a href="{{ pico_edit_url }}/logout" class="logout btn icon-switch" title="Logout"></a>
-    </div>
     <ul class="nav0">
       {% if config.pico_edit_options %}
       <li><a href="#" data-url="conf" class="post page-options"><span class="icon-equalizer2 marg-r5" aria-hidden="true"></span><i>config options</i></a></li>

--- a/editor.html
+++ b/editor.html
@@ -20,7 +20,6 @@
     <a href="#" class="pushpullbutton btn icon-download2 marg-r5" title="Git Push/Pull"></a>
     <a href="#" class="commitbutton btn icon-upload2 marg-r5" title="Git Commit"></a>
     <a href="#" class="clearcachebutton btn icon-loop2 marg-r5" title="Clear Cache"></a>
-    <a href="#" class="releasebutton btn icon-upload2 marg-r5" title="Release"></a>
     <a href="{{ pico_edit_url }}/logout" class="logout btn icon-switch" title="Logout"></a>
   </div>
   <div id="sidebar">

--- a/styles.css
+++ b/styles.css
@@ -170,19 +170,7 @@ a:hover, a:active {
   top: 1px;
 }
 
-#sidebar {
-  position: absolute;
-  top: 0;
-  left: 0;
-  bottom: 0;
-  margin-top: 35px;
-  z-index: 1;
-  width: 250px;
-  height: auto;
-  overflow: auto;
-  border-right: 1px solid #DCE0E3;
-}
-#sidebar .controls {
+.controls {
   position: fixed;
   top: 0;
   left: 0;
@@ -198,13 +186,24 @@ a:hover, a:active {
      -moz-box-shadow: 0px 1px 1px rgba(0,0,0,0.07);
           box-shadow: 0px 1px 1px rgba(0,0,0,0.07);
 }
-#sidebar .logout { 
+.controls .logout { 
   float: left; 
   margin-top: 5px;
 }
-#sidebar .controls .new, .commitbutton, .savebutton, .pushpullbutton, .clearcachebutton { 
+.controls .new, .commitbutton, .savebutton, .pushpullbutton, .clearcachebutton { 
   float: right; 
   margin-top: 5px;
+}
+#sidebar {
+  position: absolute;
+  top: 37px;
+  left: 0;
+  bottom: 0;
+  z-index: 1;
+  width: 250px;
+  height: auto;
+  overflow: auto;
+  border-right: 1px solid #DCE0E3;
 }
 #sidebar .nav0 {
   background: #f4f5f6;

--- a/styles.css
+++ b/styles.css
@@ -175,10 +175,11 @@ a:hover, a:active {
   top: 0;
   left: 0;
   bottom: 0;
+  margin-top: 35px;
   z-index: 1;
   width: 250px;
   height: 100%;
-  overflow: hidden;
+  overflow: auto;
   border-right: 1px solid #DCE0E3;
 }
 #sidebar .controls {
@@ -204,14 +205,6 @@ a:hover, a:active {
 #sidebar .controls .new, .commitbutton, .savebutton, .pushpullbutton, .clearcachebutton { 
   float: right; 
   margin-top: 5px;
-}
-#sidebar .scrollable {
-  position: absolute;
-  top: 35px;
-  left: 0;
-  bottom: 0;
-  width: 100%;
-  overflow: auto;
 }
 #sidebar .nav0 {
   background: #f4f5f6;

--- a/styles.css
+++ b/styles.css
@@ -178,7 +178,7 @@ a:hover, a:active {
   margin-top: 35px;
   z-index: 1;
   width: 250px;
-  height: 100%;
+  height: auto;
   overflow: auto;
   border-right: 1px solid #DCE0E3;
 }

--- a/styles.css
+++ b/styles.css
@@ -178,7 +178,7 @@ a:hover, a:active {
   z-index: 1;
   width: 250px;
   height: 100%;
-  overflow: auto;
+  overflow: hidden;
   border-right: 1px solid #DCE0E3;
 }
 #sidebar .controls {
@@ -201,14 +201,22 @@ a:hover, a:active {
   float: left; 
   margin-top: 5px;
 }
-#sidebar .controls .new, .commitbutton, .savebutton, .pushpullbutton, .clearcachebutton { 
+#sidebar .controls .new, .commitbutton, .savebutton, .pushpullbutton, .clearcachebutton, .releasebutton { 
   float: right; 
   margin-top: 5px;
+}
+#sidebar .scrollable {
+  position: absolute;
+  top: 35px;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  overflow: auto;
 }
 #sidebar .nav0 {
   background: #f4f5f6;
   list-style: none;
-  margin: 37px 0 0 0;
+  margin: 0;
   padding: 0;
 }
 #sidebar .nav {

--- a/styles.css
+++ b/styles.css
@@ -201,7 +201,7 @@ a:hover, a:active {
   float: left; 
   margin-top: 5px;
 }
-#sidebar .controls .new, .commitbutton, .savebutton, .pushpullbutton, .clearcachebutton, .releasebutton { 
+#sidebar .controls .new, .commitbutton, .savebutton, .pushpullbutton, .clearcachebutton { 
   float: right; 
   margin-top: 5px;
 }


### PR DESCRIPTION
This fixes a minor issue that I run into quite a bit personally.

On the sidebar file list, when you have enough files that make the scrollbar appear (Windows and Chrome OS display permanent scrollbars, unlike Mac OS X), the controls box (Save/Logout/etc.) at the top cover the top 35px of the scroll bar.

If you have not that many files, that's not too bad. For a site with thousands of files, the draggable piece of the scrollbar is very small, and can be entirely covered by the controls box on load.

This CSS change makes it so that the scrollbar starts below the controls box.

(I made a mistake with an earlier commit that made a bigger change. If you merge this pull request, please use squash and merge so your commit history stays clean.)