### PR TITLE
Use SHA256 instead of SHA1 for hashing of password

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Install
 -------
 
 1. Clone the Github repo into your 'plugins' directory (so you get a 'pico_edit' subdirectory) OR extract the zip into your 'plugins' directory (and rename the new directory to 'pico_edit')
-2. Open the Pico config.php file and insert your sha1 hashed password
+2. Open the Pico config.php file and insert your sha256 hashed password
 3. Visit http://www.yoursite.com/pico_edit and login
 
 If pages editing doesn't work check file/dir permissions of 'content' folder.

--- a/config.php
+++ b/config.php
@@ -3,8 +3,8 @@
 global $backend_password;
 
 /*
- * This should be a sha1 hash of your password.
- * Use a tool like http://www.sha1-online.com to generate.
+ * This should be a sha256 hash of your password.
+ * Use a tool like https://convertstring.com/Hash/SHA256 to generate.
  */
 $backend_password = '';
 

--- a/pico_edit.php
+++ b/pico_edit.php
@@ -44,7 +44,7 @@ final class Pico_Edit extends AbstractPicoPlugin {
 
       if( !isset($_SESSION['backend_logged_in'] ) || !$_SESSION['backend_logged_in'] ) {
         if( isset($_POST['password'] ) ) {
-          if( sha1($_POST['password'] ) == $this->password ) {
+          if( hash('sha256', $_POST['password'] ) == $this->password ) {
             $_SESSION['backend_logged_in'] = true;
             $_SESSION['backend_config'] = $twig_vars['config'];
           }


### PR DESCRIPTION
Since SHA1 is deprecated and should be avoided at all cost, it's more secure to use a different hashing method such as SHA256