### PR TITLE
Login wasn't working

### DIFF
--- a/pico_edit.php
+++ b/pico_edit.php
@@ -44,7 +44,7 @@ final class Pico_Edit extends AbstractPicoPlugin {
 
       if( !isset($_SESSION['backend_logged_in'] ) || !$_SESSION['backend_logged_in'] ) {
         if( isset($_POST['password'] ) ) {
-          if( hash('sha256', $_POST['password'] ) == $this->password ) {
+          if( strtoupper( hash('sha256', $_POST['password'])) == $this->password ) {
             $_SESSION['backend_logged_in'] = true;
             $_SESSION['backend_config'] = $twig_vars['config'];
           }


### PR DESCRIPTION
Login wasn't working because PHP hash function generates sha256 using lowercase, while most sha256 encoders use uppercase (including the suggested one https://convertstring.com/Hash/SHA256). I just wrapped the php hash function inside a strtoupper function. 